### PR TITLE
Fix no valid move found

### DIFF
--- a/src/WangLandauSimulation.jl
+++ b/src/WangLandauSimulation.jl
@@ -114,14 +114,14 @@ reject. Then increment the density of states `logdos` and histogram
 function wl_trial!(state, old_index, statedefn, logdos, histogram, logf, catchup_strategy::CatchupStrategy{C}) where {C}
 
     trial, balance_factor = random_trial!(state, statedefn)
+    isnothing(trial) && return old_index, true  # no trial move found - trigger end of current iteration
+
     new_index = histogram_index(state, statedefn, trial, old_index)
     
     old_dos = Atomix.@atomic logdos[old_index]
     new_dos = Atomix.@atomic logdos[new_index]
 
-    if isnothing(trial)     # no trial move found
-        new_index = old_index
-    elseif rand() < exp(old_dos - new_dos) * balance_factor  # faster than log(rand())
+    if rand() < exp(old_dos - new_dos) * balance_factor  # faster than log(rand())
         commit_trial!(state, statedefn, trial, old_index, new_index)
     else
         new_index = old_index
@@ -136,7 +136,7 @@ function wl_trial!(state, old_index, statedefn, logdos, histogram, logf, catchup
     Atomix.@atomic logdos[new_index] += logdos_incr
     Atomix.@atomic histogram[new_index] += 1
 
-    return new_index
+    return new_index, false
 end
 
 """
@@ -149,11 +149,12 @@ function CommonSolve.step!(sim::WangLandauSimulation, histogram, task_samples, c
     logf = current_value(logf_strategy)
 
     chunks = Base.Iterators.partition(1:sim.check_steps, chunk_size)
-    tasks = map(enumerate(chunks)) do (i, chunk)
+    tasks = map(chunks) do chunk
         Threads.@spawn begin
             state, index = initialise_state($statedefn)
-            for _ in $chunk
-                index = wl_trial!(state, index, $statedefn, logdos, histogram, $logf, $catchup_strategy)
+            for j in eachindex($chunk)
+                index, no_move_found = wl_trial!(state, index, $statedefn, logdos, histogram, $logf, $catchup_strategy)
+                no_move_found && return j
             end
             return length($chunk)
         end

--- a/src/WangLandauSimulation.jl
+++ b/src/WangLandauSimulation.jl
@@ -114,7 +114,7 @@ reject. Then increment the density of states `logdos` and histogram
 function wl_trial!(state, old_index, statedefn, logdos, histogram, logf, catchup_strategy::CatchupStrategy{C}) where {C}
 
     trial, balance_factor = random_trial!(state, statedefn)
-    isnothing(trial) && return old_index, true  # no trial move found - trigger end of current iteration
+    isnothing(trial) && return nothing  # no trial move found - trigger end of current iteration
 
     new_index = histogram_index(state, statedefn, trial, old_index)
     
@@ -136,7 +136,7 @@ function wl_trial!(state, old_index, statedefn, logdos, histogram, logf, catchup
     Atomix.@atomic logdos[new_index] += logdos_incr
     Atomix.@atomic histogram[new_index] += 1
 
-    return new_index, false
+    return new_index
 end
 
 """
@@ -153,8 +153,8 @@ function CommonSolve.step!(sim::WangLandauSimulation, histogram, task_samples, c
         Threads.@spawn begin
             state, index = initialise_state($statedefn)
             for j in eachindex($chunk)
-                index, no_move_found = wl_trial!(state, index, $statedefn, logdos, histogram, $logf, $catchup_strategy)
-                no_move_found && return j
+                index = wl_trial!(state, index, $statedefn, logdos, histogram, $logf, $catchup_strategy)
+                isnothing(index) && return j
             end
             return length($chunk)
         end

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -47,6 +47,7 @@ end
     Random.seed!(1234)
 
     L = 5
+    # NB: Ising2D example uses Int to index histogram
     statedefn = Ising2D(L; periodic = false)
     prob = WangLandauProblem(statedefn)
 


### PR DESCRIPTION
Fix a case where no trial move is found and simulation runs forever on the same state